### PR TITLE
[ADD] udes-tester: Add packages required for running selenium tests

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,11 +2,24 @@ FROM unipartdigital/odoo-tester
 
 # Packages
 #
-RUN dnf install -y python3-paramiko python3-ply python3-xlwt ; \
+RUN dnf install -y fedora-workstation-repositories dnf-plugins-core; \
+    dnf config-manager --set-enabled google-chrome; \
+    dnf install -y python3-paramiko python3-ply python3-xlwt \
+                   python3-click python3-xlrd python3-selenium \
+                   chromedriver google-chrome-stable \
+                   xorg-x11-server-Xvfb cups-pdf xorg-x11-fonts-Type1 \
+                   xorg-x11-fonts-75dpi compat-openssl10 libpng15; \
     dnf clean all
+
+RUN wget https://github.com/wkhtmltopdf/wkhtmltopdf/releases/download/0.12.1/wkhtmltox-0.12.1_linux-centos7-amd64.rpm; \
+    rpm -ivh wkhtmltox-0.12.1_linux-centos7-amd64.rpm
+
+USER odoo
+RUN pip3 install --user odoorpc
 
 # UDES Odoo snapshot
 #
+USER root
 ADD https://codeload.github.com/unipartdigital/odoo/zip/udes-${ODOO_VERSION} \
     /opt/odoo.zip
 RUN rm -rf /opt/odoo /opt/odoo-${ODOO_VERSION} \


### PR DESCRIPTION
chromedriver, google-chrome-stable, xorg-x11-server-Xvfb,
python3-selenium python3-click python3-xlrd odoorpc
are all required for running selenium

cups-pdf and wkhtmltox is required for printing tests

xorg-x11-fonts-*, compat-openssl10 and libpng15 are
required for wkhtmltox

Signed-off-by: Michele Costa <michele.costa@unipart.io>