### PR TITLE
[IMP] remove odoo server init

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,8 +25,3 @@ RUN rm -rf /opt/odoo /opt/odoo-${ODOO_VERSION} \
 	   /opt/odoo-udes-${ODOO_VERSION} ; \
     unzip -q -d /opt /opt/odoo.zip ; \
     ln -s odoo-udes-${ODOO_VERSION} /opt/odoo
-
-# Prerequisite module installation (without tests)
-#
-RUN odoo-wrapper --without-demo=all -i \
-    project,document,product,stock,stock_picking_batch,purchase,mrp


### PR DESCRIPTION
This installs modules on a db called 'odoo', which we subsequently do
not use for any of our tests. Therefore, it is unnecessary.

Task: 3716

Signed-off-by: Samuel Searles-Bryant <samuel.searles-bryant@unipart.io>