### PR TITLE
[FIX] pyYAML version downgrade

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN dnf install -y fedora-workstation-repositories dnf-plugins-core ; \
 # Non-distro packages
 #
 USER odoo
-RUN pip3 install --user odoorpc
+RUN pip3 install --user odoorpc "pyyaml<5.1"
 
 # UDES Odoo snapshot
 #


### PR DESCRIPTION
There is a known issue with pyYAML 5.1 (yaml/pyyaml#274) which does not assign
a default loader to the add_constructor method. This ensures that a
pre-5.1 version of pyYAML is being used.

Task: 3716

Signed-off-by: Samuel Searles-Bryant <samuel.searles-bryant@unipart.io>