### PR TITLE
[FIX] chromedriver version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ FROM unipartdigital/odoo-tester
 RUN dnf install -y fedora-workstation-repositories dnf-plugins-core ; \
     dnf config-manager --set-enabled google-chrome ; \
     dnf install -y python3-paramiko python3-ply python3-click \
-		   python3-selenium chromedriver google-chrome-stable \
+		   python3-selenium google-chrome-stable \
 		   xorg-x11-server-Xvfb cups-pdf xorg-x11-fonts-Type1 \
 		   xorg-x11-fonts-75dpi python3-requests python3-shortuuid \
            python3-pyicu; \
@@ -15,6 +15,13 @@ RUN dnf install -y fedora-workstation-repositories dnf-plugins-core ; \
 #
 USER odoo
 RUN pip3 install --user odoorpc "pyyaml<5.1"
+
+## Download a compatible version of chromedriver
+## TODO (ssb): this is temporary, remove this block and use dnf when the distro version is up to date.
+USER root
+ADD https://chromedriver.storage.googleapis.com/74.0.3729.6/chromedriver_linux64.zip /bin/chromedriver.zip
+RUN unzip -d /bin /bin/chromedriver.zip
+RUN chmod a+x /bin/chromedriver
 
 # UDES Odoo snapshot
 #


### PR DESCRIPTION
The distro version of google-chrome-stable has been upgraded to 74,
whereas the distro version of chromedriver is still 73. These are
incompatible.

This commit explicitely downloads and adds to PATH version 74 of
chromedriver (latest as of today).

Issue: 3933

Signed-off-by: Samuel Searles-Bryant <samuel.searles-bryant@unipart.io>