### PR TITLE
[IMP] add pipenv

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ FROM unipartdigital/odoo-tester
 RUN dnf install -y fedora-workstation-repositories dnf-plugins-core ; \
     dnf config-manager --set-enabled google-chrome ; \
     dnf install -y python3-paramiko python3-ply python3-click \
-		   python3-selenium google-chrome-stable \
+		   python3-selenium google-chrome-stable pipenv\
 		   xorg-x11-server-Xvfb cups-pdf xorg-x11-fonts-Type1 \
 		   xorg-x11-fonts-75dpi python3-requests python3-shortuuid \
            python3-pyicu; \


### PR DESCRIPTION
Install Pipenv for creating the environment for the selenium tests to
run in. (N.B. This does not affect the environment UDES is run in.)

Task: 4274

Signed-off-by: Samuel Searles-Bryant <samuel.searles-bryant@unipart.io>