### PR TITLE
    [IMP] update chromedriver version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN pip3 install --user unittest-xml-reporting
 ## Download a compatible version of chromedriver
 ## TODO (ssb): this is temporary, remove this block and use dnf when the distro version is up to date.
 USER root
-ADD https://chromedriver.storage.googleapis.com/76.0.3809.68/chromedriver_linux64.zip /bin/chromedriver.zip
+ADD https://chromedriver.storage.googleapis.com/78.0.3904.70/chromedriver_linux64.zip /bin/chromedriver.zip
 RUN unzip -d /bin /bin/chromedriver.zip
 RUN chmod a+x /bin/chromedriver
 


### PR DESCRIPTION
    The dnf stable version of Chrome is now 78, so the chromedriver needs to
    be updated to reflect this.

    Task: 190

This was causing all the selenium tests to fail.
I've built and tested the docker containers locally.

https://taiga.unipart.digital/project/udescore/task/8970?kanban-status=178