### PR TITLE
[IMP] Remove pip installs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,13 +11,7 @@ RUN dnf install -y fedora-workstation-repositories dnf-plugins-core ; \
 		   postgresql-contrib python3-paho-mqtt; \
     dnf clean all
 
-# Non-distro packages
-#
-USER odoo
-RUN pip3 install --user unittest-xml-reporting
-RUN pip3 install --user ortools
-RUN pip3 install --user mock
-RUN pip3 install --user python-barcode
+# Non-distro packages should be installed downstream to minimise image rebuilds.
 
 ## Download a compatible version of chromedriver
 #


### PR DESCRIPTION
Pip installs should be made in downstream Dockerfiles, to minimise image
rebuilds.

Signed-off-by: Kevin Dwyer <kevin.dwyer@unipart.io>